### PR TITLE
Skipped steps should not fail the executing script

### DIFF
--- a/seleniumbuilder/chrome/content/html/js/builder/selenium2/playback.js
+++ b/seleniumbuilder/chrome/content/html/js/builder/selenium2/playback.js
@@ -1373,7 +1373,7 @@ builder.selenium2.playback.playStep = function() {
       builder.selenium2.playback.recordError(_t('sel2_step_not_implemented_for_playback', builder.selenium2.playback.currentStep.type));
     }
   } else {
-    builder.selenium2.playback.recordResult({success: false, message: _t('sel2_bypass', builder.selenium2.playback.byPassCounter--)});
+    builder.selenium2.playback.recordResult({success: false, message: _t('sel2_bypass', builder.selenium2.playback.byPassCounter--), skip: true});
   }
 };
 
@@ -1392,16 +1392,20 @@ builder.selenium2.playback.recordResult = function(result) {
     result.message = msg;
     result.success = !result.success;
   }
-  if (result.success) {
+  if (result.skip) {
+    builder.selenium2.playback.stepStateCallback(builder.selenium2.playback, builder.selenium2.playback.script, builder.selenium2.playback.currentStep, builder.selenium2.playback.currentStepIndex(), builder.stepdisplay.state.SUCCEEDED, null, null);
+  } else if (result.success) {
     builder.selenium2.playback.stepStateCallback(builder.selenium2.playback, builder.selenium2.playback.script, builder.selenium2.playback.currentStep, builder.selenium2.playback.currentStepIndex(), builder.stepdisplay.state.SUCCEEDED, null, null);
     if (result.success && builder.selenium2.playback.currentStep.type.getName().startsWith("bypass")) {
       builder.selenium2.playback.byPassCounter = builder.selenium2.playback.currentStep.nbstep;
     }
   } else {
-    builder.selenium2.playback.stepStateCallback(builder.selenium2.playback, builder.selenium2.playback.script, builder.selenium2.playback.currentStep, builder.selenium2.playback.currentStepIndex(), builder.stepdisplay.state.FAILED, null, result.message);
-    builder.selenium2.playback.playResult.success = false;
-    if (result.message) {
-      builder.selenium2.playback.playResult.errormessage = result.message;
+    if (!builder.selenium2.playback.currentStep.type.getName().startsWith("bypass")) {
+      builder.selenium2.playback.stepStateCallback(builder.selenium2.playback, builder.selenium2.playback.script, builder.selenium2.playback.currentStep, builder.selenium2.playback.currentStepIndex(), builder.stepdisplay.state.FAILED, null, result.message);
+      builder.selenium2.playback.playResult.success = false;
+      if (result.message) {
+        builder.selenium2.playback.playResult.errormessage = result.message;
+      }
     }
   }
 

--- a/seleniumbuilder/chrome/content/html/js/builder/selenium2/playback.js
+++ b/seleniumbuilder/chrome/content/html/js/builder/selenium2/playback.js
@@ -1393,15 +1393,17 @@ builder.selenium2.playback.recordResult = function(result) {
     result.success = !result.success;
   }
   if (result.skip) {
-    builder.selenium2.playback.stepStateCallback(builder.selenium2.playback, builder.selenium2.playback.script, builder.selenium2.playback.currentStep, builder.selenium2.playback.currentStepIndex(), builder.stepdisplay.state.SUCCEEDED, null, null);
+    // Skipped steps should be updated with a distinct UI treatment
+    builder.selenium2.playback.stepStateCallback(builder.selenium2.playback, builder.selenium2.playback.script, builder.selenium2.playback.currentStep, builder.selenium2.playback.currentStepIndex(), builder.stepdisplay.state.SKIPPED, null, null);
   } else if (result.success) {
     builder.selenium2.playback.stepStateCallback(builder.selenium2.playback, builder.selenium2.playback.script, builder.selenium2.playback.currentStep, builder.selenium2.playback.currentStepIndex(), builder.stepdisplay.state.SUCCEEDED, null, null);
     if (result.success && builder.selenium2.playback.currentStep.type.getName().startsWith("bypass")) {
       builder.selenium2.playback.byPassCounter = builder.selenium2.playback.currentStep.nbstep;
     }
   } else {
+    // Bypass steps are not real failures, but we're setting the display to "FAILED" so it's more obvious when Se-Builder runs/skips the bypassable steps
+    builder.selenium2.playback.stepStateCallback(builder.selenium2.playback, builder.selenium2.playback.script, builder.selenium2.playback.currentStep, builder.selenium2.playback.currentStepIndex(), builder.stepdisplay.state.FAILED, null, result.message);
     if (!builder.selenium2.playback.currentStep.type.getName().startsWith("bypass")) {
-      builder.selenium2.playback.stepStateCallback(builder.selenium2.playback, builder.selenium2.playback.script, builder.selenium2.playback.currentStep, builder.selenium2.playback.currentStepIndex(), builder.stepdisplay.state.FAILED, null, result.message);
       builder.selenium2.playback.playResult.success = false;
       if (result.message) {
         builder.selenium2.playback.playResult.errormessage = result.message;

--- a/seleniumbuilder/chrome/content/html/js/builder/stepdisplay.js
+++ b/seleniumbuilder/chrome/content/html/js/builder/stepdisplay.js
@@ -8,6 +8,7 @@ builder.stepdisplay.state.SUCCEEDED = 2;
 builder.stepdisplay.state.FAILED = 3;
 builder.stepdisplay.state.ERROR = 4;
 builder.stepdisplay.state.BREAKPOINT = 5;
+builder.stepdisplay.state.SKIPPED = 6;
 
 builder.stepdisplay.stateColors = {};
 builder.stepdisplay.stateColors[builder.stepdisplay.state.NORMAL] = 'white';
@@ -16,6 +17,7 @@ builder.stepdisplay.stateColors[builder.stepdisplay.state.SUCCEEDED] = '#bfee85'
 builder.stepdisplay.stateColors[builder.stepdisplay.state.FAILED] = '#ffcccc';
 builder.stepdisplay.stateColors[builder.stepdisplay.state.ERROR] = '#ff3333';
 builder.stepdisplay.stateColors[builder.stepdisplay.state.BREAKPOINT] = '#e0d5e9';
+builder.stepdisplay.stateColors[builder.stepdisplay.state.SKIPPED] = '#ffc048';
 
 builder.registerPostLoadHook(function() {
   jQuery('#suite-saverequired').text(_t('suite_has_unsaved_changes'));


### PR DESCRIPTION
The current implementation of the 'bypass' step types marks each skipped step as 'failed', which makes se-builder incorrectly report the test as failed.  I have modified the logic to update the status of the skipped steps as 'passed' so the overall test reporting is still accurate.
